### PR TITLE
edit main.dart

### DIFF
--- a/orange/lib/main.dart
+++ b/orange/lib/main.dart
@@ -104,14 +104,19 @@ class _MyListPageState extends State<MyListPage> {
         body: ListView.builder(
           itemCount: todo_items.length,
           itemBuilder: (BuildContext context, int index) {
-            return Card(
-              child: Column(
-                children: <Widget>[
-                  ListTile(
-                    title: Text(todo_items[index]['title']),
-                    subtitle: Text(todo_items[index]['description']),
-                  )
-                ],
+            return GestureDetector(
+              onTap: () {
+                log(todo_items[index]['id'].toString());
+              },
+              child: Card(
+                child: Column(
+                  children: <Widget>[
+                    ListTile(
+                      title: Text(todo_items[index]['title']),
+                      subtitle: Text(todo_items[index]['description']),
+                    )
+                  ],
+                ),
               ),
             );
           },


### PR DESCRIPTION
リストビューの画面にて、Cardで実装していた部分をクリック(onTap)するとその詳細が表示される画面へ遷移させる、という処理を今後追加していく。

そのために、リストビューで並んでいるCardをクリック(onTap)とそのときのidを拾うあたりを実装した。