### PR TITLE
TodoのCRUD処理を追加

### DIFF
--- a/grape/README.md
+++ b/grape/README.md
@@ -1,16 +1,9 @@
 # grape
 
-A new Flutter project.
+REST APIを使ったTodoアプリ。
 
-## Getting Started
+## 内容
 
-This project is a starting point for a Flutter application.
-
-A few resources to get you started if this is your first Flutter project:
-
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
-
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+- Provider,go_routerを使用
+- get_itでrepositoryの切り替えを行う
+- REST APIと通信を行っている(http使用)

--- a/grape/lib/edit_page.dart
+++ b/grape/lib/edit_page.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get_it/get_it.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+
+import 'main_state.dart';
+import 'model/api/todo_api.dart';
+import 'model/entity/todo.dart';
+
+class _FormState extends ChangeNotifier {
+  late Todo? todo;
+  late bool isNew;
+  late String screenName;
+
+  late TextEditingController _titleField;
+  late TextEditingController _descriptionField;
+
+  bool _isSending = false;
+  bool get isSending => _isSending;
+
+  var todoApi = TodoApi();
+
+  _FormState({required this.todo}) {
+    _titleField = TextEditingController();
+    _descriptionField = TextEditingController();
+
+    if (todo == null) {
+      screenName = 'Add';
+      isNew = true;
+    } else {
+      screenName = 'Edit';
+      isNew = false;
+      _titleField.text = todo!.title;
+      _descriptionField.text = todo!.description;
+    }
+  }
+
+  TextEditingController get titleField => _titleField;
+  TextEditingController get descriptionField => _descriptionField;
+
+  Future<void> createTodo() async {
+    _startSending();
+    await todoApi.createTodo(titleField.text, descriptionField.text);
+    _finishSending();
+  }
+
+  Future<void> updateTodo() async {
+    _startSending();
+    if (todo != null) {
+      todo!.title = _titleField.text;
+      todo!.description = _descriptionField.text;
+      await todoApi.updateTodo(todo!);
+    }
+    _finishSending();
+  }
+
+  void _startSending() {
+    _isSending = true;
+    notifyListeners();
+  }
+
+  void _finishSending() {
+    _isSending = false;
+    notifyListeners();
+  }
+}
+
+// ignore: must_be_immutable
+class EditPage extends StatelessWidget {
+  final _formKey = GlobalKey<FormState>();
+
+  static String routeName = 'editTodo';
+
+  late _FormState _formState;
+
+  EditPage({super.key, Todo? todo}) {
+    _formState = _FormState(todo: todo);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider.value(
+      value: _formState,
+      child: Scaffold(
+        appBar: AppBar(title: Text(_formState.screenName)),
+        body: Center(
+          child: _getForm(context),
+        ),
+        floatingActionButton: FloatingActionButton(
+          onPressed: () async {
+            if (_formState.isNew) {
+              await _formState.createTodo();
+            } else {
+              await _formState.updateTodo();
+            }
+            await GetIt.I<MainState>().readTodos();
+            // ignore: use_build_context_synchronously
+            context.pop('/');
+          },
+          child: Icon(_formState.isNew ? Icons.add : Icons.edit),
+        ),
+      ),
+    );
+  }
+
+  Widget _getForm(BuildContext context) {
+    return Form(
+      key: _formKey,
+      child: ListView(
+        padding: const EdgeInsets.all(16),
+        children: _getFormWidgets(context),
+      ),
+    );
+  }
+
+  List<Widget> _getFormWidgets(BuildContext context) {
+    List<Widget> formWidget = [];
+
+    formWidget.add(
+      TextFormField(
+        controller: _formState.titleField,
+        decoration:
+            const InputDecoration(labelText: 'Title', hintText: 'Title'),
+      ),
+    );
+
+    formWidget.add(
+      TextFormField(
+        controller: _formState.descriptionField,
+        decoration: const InputDecoration(
+            labelText: 'Description', hintText: 'Description'),
+      ),
+    );
+
+    return formWidget;
+  }
+}

--- a/grape/lib/home_page.dart
+++ b/grape/lib/home_page.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:grape/main_state.dart';
 import 'package:provider/provider.dart';
+
+import 'edit_page.dart';
+import 'model/entity/todo.dart';
 
 class HomePage extends StatelessWidget {
   static String routeName = '/';
@@ -13,6 +17,12 @@ class HomePage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: Text(screenName)),
       body: buildTodoList(context),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          context.push('/${EditPage.routeName}');
+        },
+        child: const Icon(Icons.add),
+      ),
     );
   }
 
@@ -31,13 +41,13 @@ class HomePage extends StatelessWidget {
       child: ListView.builder(
         itemCount: mainState.todoItems.length,
         itemBuilder: (context, index) {
-          return Card(
-            child: Column(children: <Widget>[
-              ListTile(
-                title: Text(mainState.todoItems[index].title),
-                subtitle: Text(mainState.todoItems[index].description),
-              )
-            ]),
+          Todo currentTodo = mainState.todoItems[index];
+          return ListTile(
+            title: Text(currentTodo.title),
+            subtitle: Text(currentTodo.description),
+            onTap: () {
+              context.push('/${EditPage.routeName}/$index');
+            },
           );
         },
       ),

--- a/grape/lib/home_page.dart
+++ b/grape/lib/home_page.dart
@@ -42,12 +42,17 @@ class HomePage extends StatelessWidget {
         itemCount: mainState.todoItems.length,
         itemBuilder: (context, index) {
           Todo currentTodo = mainState.todoItems[index];
-          return ListTile(
-            title: Text(currentTodo.title),
-            subtitle: Text(currentTodo.description),
+          return GestureDetector(
             onTap: () {
               context.push('/${EditPage.routeName}/$index');
             },
+            onDoubleTap: () async {
+              mainState.deleteTodo(mainState.todoItems[index].id);
+            },
+            child: ListTile(
+              title: Text(currentTodo.title),
+              subtitle: Text(currentTodo.description),
+            ),
           );
         },
       ),

--- a/grape/lib/main.dart
+++ b/grape/lib/main.dart
@@ -65,6 +65,8 @@ class MyApp extends StatelessWidget {
         useMaterial3: true,
       ),
       routerConfig: _router,
+      debugShowCheckedModeBanner: false,
+      debugShowMaterialGrid: false,
     );
   }
 }

--- a/grape/lib/main.dart
+++ b/grape/lib/main.dart
@@ -31,6 +31,10 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp.router(
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+        useMaterial3: true,
+      ),
       routerConfig: _router,
     );
   }

--- a/grape/lib/main.dart
+++ b/grape/lib/main.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
+import 'package:grape/edit_page.dart';
 import 'package:provider/provider.dart';
 
 import 'home_page.dart';
 import 'main_state.dart';
+import 'model/entity/todo.dart';
 
 final _router = GoRouter(
   routes: [
@@ -12,14 +15,40 @@ final _router = GoRouter(
       builder: (context, state) {
         return const HomePage();
       },
+      routes: [
+        GoRoute(
+          name: 'EditTodo',
+          path: '${EditPage.routeName}/:id',
+          builder: (context, state) {
+            final id = state.pathParameters['id'];
+            if (id == null) {
+              return EditPage();
+            } else {
+              Todo? todo =
+                  Provider.of<MainState>(context).todoItems[int.parse(id)];
+              return EditPage(todo: todo);
+            }
+          },
+        ),
+        GoRoute(
+          name: 'AddTodo',
+          path: EditPage.routeName,
+          builder: (context, state) {
+            return EditPage();
+          },
+        ),
+      ],
     ),
   ],
 );
 
 void main(List<String> args) {
+  GetIt.instance.registerLazySingleton(() => MainState());
   runApp(
     MultiProvider(
-      providers: [ChangeNotifierProvider(create: (_) => MainState())],
+      providers: [
+        ChangeNotifierProvider<MainState>.value(value: GetIt.I<MainState>())
+      ],
       child: const MyApp(),
     ),
   );

--- a/grape/lib/main_state.dart
+++ b/grape/lib/main_state.dart
@@ -23,6 +23,13 @@ class MainState with ChangeNotifier {
     _finishLoading();
   }
 
+  Future<void> deleteTodo(int id) async {
+    _startLoading();
+    await _todoRepository.deleteTodoById(id);
+    _todoItems = await _todoRepository.readAllTodos();
+    _finishLoading();
+  }
+
   void _startLoading() {
     _isLoading = true;
     notifyListeners();

--- a/grape/lib/model/api/todo_api.dart
+++ b/grape/lib/model/api/todo_api.dart
@@ -14,4 +14,65 @@ class TodoApi implements TodoRepository {
 
     return jsonRes.map<Todo>((map) => Todo.fromJson(map)).toList();
   }
+
+  @override
+  Future<Todo?> readTodoById(int id) async {
+    var response = await http.get(Uri.http('127.0.0.1:5000', 'api/todos/$id'));
+    if (response.statusCode == 200) {
+      var jsonRes = jsonDecode(utf8.decode(response.bodyBytes));
+      return Todo.fromJson(jsonRes);
+    } else {
+      return null;
+    }
+  }
+
+  @override
+  Future<bool> createTodo(String title, String description) async {
+    Map<String, String> headers = {'content-type': 'application/json'};
+    var body = jsonEncode({
+      'title': title,
+      'description': description,
+    });
+    final response = await http.post(
+      Uri.http('127.0.0.1:5000', 'api/todos'),
+      headers: headers,
+      body: body,
+    );
+    if (response.statusCode == 200) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  @override
+  Future<bool> updateTodo(Todo todo) async {
+    Map<String, String> headers = {'content-type': 'application/json'};
+    var body = jsonEncode({
+      'title': todo.title,
+      'description': todo.description,
+    });
+    final response = await http.put(
+      Uri.http('127.0.0.1:5000', 'api/todos/${todo.id}'),
+      headers: headers,
+      body: body,
+    );
+    if (response.statusCode == 200) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  @override
+  Future<bool> deleteTodoById(int id) async {
+    final response =
+        await http.delete(Uri.http('127.0.0.1:5000', 'api/todos/$id'));
+    if (response.statusCode == 200) {
+      return true;
+    } else {
+      return false;
+      //throw Exception('Failed to delete Todo');
+    }
+  }
 }

--- a/grape/lib/model/repository/todo_repository.dart
+++ b/grape/lib/model/repository/todo_repository.dart
@@ -2,4 +2,8 @@ import '../entity/todo.dart';
 
 abstract class TodoRepository {
   Future<List<Todo>> readAllTodos();
+  Future<Todo?> readTodoById(int id);
+  Future<bool> createTodo(String title, String description);
+  Future<bool> updateTodo(Todo todo);
+  Future<bool> deleteTodoById(int id);
 }

--- a/grape/pubspec.lock
+++ b/grape/pubspec.lock
@@ -112,6 +112,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.18.1"
   js:
     dependency: transitive
     description:

--- a/grape/pubspec.yaml
+++ b/grape/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   go_router: ^8.0.3
   get_it: ^7.6.0
   http: ^0.13.0
+  intl: ^0.18.1
 
 dev_dependencies:
   flutter_test:

--- a/grape/test/model/todo_repository_test.dart
+++ b/grape/test/model/todo_repository_test.dart
@@ -1,9 +1,50 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:grape/model/api/todo_api.dart';
+import 'package:grape/model/entity/todo.dart';
+import 'package:intl/intl.dart';
 
 void main() {
   test('repository api todo', () async {
     var api = TodoApi();
-    api.readAllTodos();
+    await api.readAllTodos();
+  });
+
+  test('create todo', () async {
+    var api = TodoApi();
+    await api.createTodo('test1 title', 'test1 description');
+  });
+
+  test('read todo', () async {
+    var api = TodoApi();
+    Todo? todo = await api.readTodoById(6);
+    expect(todo, isNotNull);
+    expect(todo, isInstanceOf<Todo>());
+  });
+
+  test('update todo', () async {
+    var api = TodoApi();
+    Todo? todo = await api.readTodoById(6);
+
+    expect(todo, isNotNull);
+    expect(todo, isInstanceOf<Todo>());
+
+    var now = DateTime.now();
+    String nowStr = DateFormat('yyyyMMddhhmm').format(now);
+    String updateTitle = todo!.title + nowStr;
+    todo.title = updateTitle;
+    await api.updateTodo(todo);
+
+    Todo? todo2 = await api.readTodoById(6);
+    expect(todo2, isNotNull);
+    expect(todo2, isInstanceOf<Todo>());
+    expect(todo2!.title, equals(updateTitle));
+  });
+
+  test('delete todo', () async {
+    var api = TodoApi();
+    await api.deleteTodoById(6);
+
+    Todo? todo = await api.readTodoById(6);
+    expect(todo, isNull);
   });
 }


### PR DESCRIPTION
change todo_api.dart:todo_api.dartにapiを通じて掲題のような処理を行うようプログラムを追加した。

change README.md:デフォルトの状態からの変更。

change Theme: main.dartにて、Material3をtrueにした。

追加編集処理の追加:edit_page.dartにてEditPageというクラスを追加。これは追加と編集両方につかわれて、引数に応じて、行う処理をかえる。あとは、それを使うように関連するファイルを変更した。

debug消す:右上に表示されていた、debugの文字をけした。

削除処理　追加:home_page.dartにてTodoがリスト表示されている画面にて、Todoを消すように処理を追加した。