### PR TITLE
リストにて、スワイプにて削除するよう変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ flask --app prog/todo run
 
 ## クライアント
 
-orangeディレクトリに移動して次を実行。
+grapeディレクトリに移動して次を実行。
 
 ```
 flutter run

--- a/grape/lib/home_page.dart
+++ b/grape/lib/home_page.dart
@@ -42,16 +42,19 @@ class HomePage extends StatelessWidget {
         itemCount: mainState.todoItems.length,
         itemBuilder: (context, index) {
           Todo currentTodo = mainState.todoItems[index];
-          return GestureDetector(
-            onTap: () {
-              context.push('/${EditPage.routeName}/$index');
+          return Dismissible(
+            key: ValueKey<int>(currentTodo.id),
+            onDismissed: (direction) async {
+              await mainState.deleteTodo(mainState.todoItems[index].id);
             },
-            onDoubleTap: () async {
-              mainState.deleteTodo(mainState.todoItems[index].id);
-            },
-            child: ListTile(
-              title: Text(currentTodo.title),
-              subtitle: Text(currentTodo.description),
+            child: GestureDetector(
+              onTap: () {
+                context.push('/${EditPage.routeName}/$index');
+              },
+              child: ListTile(
+                title: Text(currentTodo.title),
+                subtitle: Text(currentTodo.description),
+              ),
             ),
           );
         },


### PR DESCRIPTION
home_page.dartのリストビューで、今まではダブルタップで削除、シングルタップで詳細と処理を分けていたけれど、これをスワイプにて削除するように変更した。